### PR TITLE
Change runner to use better featured mgba-qt

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,7 +11,7 @@ rustflags = [
   "-Ctarget-cpu=arm7tdmi",
   "-Cforce-frame-pointers=yes",
 ]
-runner = ["mgba", "-C", "logToStdout=1", "-C", "logLevel.gba.debug=127"]
+runner = ["mgba-qt", "-C", "logToStdout=1", "-C", "logLevel.gba.debug=127"]
 
 [target.armv4t-none-eabi]
 rustflags = [
@@ -19,4 +19,4 @@ rustflags = [
   "-Ctarget-cpu=arm7tdmi",
   "-Cforce-frame-pointers=yes",
 ]
-runner = ["mgba", "-C", "logToStdout=1", "-C", "logLevel.gba.debug=127"]
+runner = ["mgba-qt", "-C", "logToStdout=1", "-C", "logLevel.gba.debug=127"]


### PR DESCRIPTION
For me, the  command `mgba` launches a version of the emulator with seemingly no options bar. `mgba-qt` is the normal version of the emulator.